### PR TITLE
Potential fix for code scanning alert no. 34: Incomplete URL substring sanitization

### DIFF
--- a/staticfiles/leaflet-routing-machine/leaflet-routing-machine.js
+++ b/staticfiles/leaflet-routing-machine/leaflet-routing-machine.js
@@ -17927,19 +17927,25 @@ module.exports = L.Routing = {
 				locations: {}
 			};
 
-			if (!this.options.suppressDemoServerWarning &&
-				this.options.serviceUrl.indexOf('//router.project-osrm.org') >= 0) {
-				console.warn('You are using OSRM\'s demo server. ' +
-					'Please note that it is **NOT SUITABLE FOR PRODUCTION USE**.\n' +
-					'Refer to the demo server\'s usage policy: ' +
-					'https://github.com/Project-OSRM/osrm-backend/wiki/Api-usage-policy\n\n' +
-					'To change, set the serviceUrl option.\n\n' +
-					'Please do not report issues with this server to neither ' +
-					'Leaflet Routing Machine or OSRM - it\'s for\n' +
-					'demo only, and will sometimes not be available, or work in ' +
-					'unexpected ways.\n\n' +
-					'Please set up your own OSRM server, or use a paid service ' +
-					'provider for production.');
+			if (!this.options.suppressDemoServerWarning) {
+				try {
+					const parsedUrl = new URL(this.options.serviceUrl);
+					if (parsedUrl.host === 'router.project-osrm.org') {
+						console.warn('You are using OSRM\'s demo server. ' +
+							'Please note that it is **NOT SUITABLE FOR PRODUCTION USE**.\n' +
+							'Refer to the demo server\'s usage policy: ' +
+							'https://github.com/Project-OSRM/osrm-backend/wiki/Api-usage-policy\n\n' +
+							'To change, set the serviceUrl option.\n\n' +
+							'Please do not report issues with this server to neither ' +
+							'Leaflet Routing Machine or OSRM - it\'s for\n' +
+							'demo only, and will sometimes not be available, or work in ' +
+							'unexpected ways.\n\n' +
+							'Please set up your own OSRM server, or use a paid service ' +
+							'provider for production.');
+					}
+				} catch (e) {
+					console.error('Invalid serviceUrl provided:', this.options.serviceUrl);
+				}
 			}
 		},
 


### PR DESCRIPTION
Potential fix for [https://github.com/kuth-chi/auth-server/security/code-scanning/34](https://github.com/kuth-chi/auth-server/security/code-scanning/34)

To fix the issue, the code should parse the URL and explicitly check the host value to ensure it matches `router.project-osrm.org`. This approach avoids the pitfalls of substring checks and ensures that the host is correctly validated. The `URL` class, available in modern JavaScript environments, can be used to parse the URL and extract the host.

The fix involves replacing the substring check with a host validation using the `URL` class. Specifically:
1. Parse `this.options.serviceUrl` using the `URL` class.
2. Compare the `host` property of the parsed URL with the expected host `router.project-osrm.org`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
