### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/static/libs/flowbite/dist/flowbite.turbo.js
+++ b/static/libs/flowbite/dist/flowbite.turbo.js
@@ -5677,7 +5677,7 @@ var CopyClipboard = /** @class */ (function () {
         var textToCopy = this.getTargetValue();
         // Check if HTMLEntities option is enabled
         if (this._options.htmlEntities) {
-            // Encode the text using HTML entities
+            // Safely decode the text while escaping meta-characters
             textToCopy = this.decodeHTML(textToCopy);
         }
         // Create a temporary textarea element
@@ -5693,11 +5693,21 @@ var CopyClipboard = /** @class */ (function () {
         this._options.onCopy(this);
         return textToCopy;
     };
-    // Function to encode text into HTML entities
+    // Function to safely decode HTML entities while escaping meta-characters
     CopyClipboard.prototype.decodeHTML = function (html) {
         var textarea = document.createElement('textarea');
         textarea.innerHTML = html;
-        return textarea.textContent;
+        var decodedText = textarea.textContent || '';
+        // Escape meta-characters to prevent XSS
+        return decodedText.replace(/[&<>"']/g, function (char) {
+            return {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            }[char];
+        });
     };
     CopyClipboard.prototype.updateOnCopyCallback = function (callback) {
         this._options.onCopy = callback;


### PR DESCRIPTION
Potential fix for [https://github.com/kuth-chi/auth-server/security/code-scanning/9](https://github.com/kuth-chi/auth-server/security/code-scanning/9)

To fix the issue, we need to ensure that the input passed to `decodeHTML` is sanitized or escaped to prevent the interpretation of malicious HTML. Instead of directly decoding the HTML entities, we should use a safer approach to handle the text. Specifically, we can replace the `decodeHTML` method with a function that escapes potentially dangerous characters, ensuring that the decoded content cannot execute malicious scripts.

Changes to make:
1. Replace the `decodeHTML` method with a safer implementation that escapes HTML meta-characters.
2. Update the `copy` method to use the new implementation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
