### PR TITLE
Potential fix for code scanning alert no. 37: URL redirection from remote source

### DIFF
--- a/user/views/user_view.py
+++ b/user/views/user_view.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 from django.contrib import messages
 from django.http import HttpResponse
 from django.shortcuts import render, redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.contrib.auth import authenticate, login, logout
 from user.models import User, Profile
 from user.forms.user_forms import RegisterForm, CustomerAuthenticationForm
@@ -60,7 +61,7 @@ def user_login(request):
             login(request, user)
 
             next_url = request.GET.get('next')
-            if not next_url or next_url.startswith('/accounts/login'):
+            if not url_has_allowed_host_and_scheme(next_url, allowed_hosts=None):
                 next_url = '/'
 
             code = request.COOKIES.get('authorization_code')


### PR DESCRIPTION
Potential fix for [https://github.com/kuth-chi/auth-server/security/code-scanning/37](https://github.com/kuth-chi/auth-server/security/code-scanning/37)

To fix the issue, we need to validate the `next_url` parameter before using it in the `redirect()` function. The best approach is to use Django's `url_has_allowed_host_and_scheme` utility function, which ensures that the URL is safe for redirection. This function checks that the URL belongs to allowed hosts and has a valid scheme.

Steps to fix:
1. Import `url_has_allowed_host_and_scheme` from `django.utils.http`.
2. Validate `next_url` using `url_has_allowed_host_and_scheme` with `allowed_hosts` set to `None` (default to the application's allowed hosts).
3. If `next_url` is invalid, redirect to a safe default URL (e.g., `/`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
