### PR TITLE
Potential fix for code scanning alert no. 38: DOM text reinterpreted as HTML

### DIFF
--- a/static/libs/flowbite/dist/flowbite.turbo.js
+++ b/static/libs/flowbite/dist/flowbite.turbo.js
@@ -5695,9 +5695,22 @@ var CopyClipboard = /** @class */ (function () {
     };
     // Function to safely decode HTML entities while escaping meta-characters
     CopyClipboard.prototype.decodeHTML = function (html) {
-        var textarea = document.createElement('textarea');
-        textarea.innerHTML = html;
-        var decodedText = textarea.textContent || '';
+        // Decode HTML entities using a safer approach
+        var decodedText = html.replace(/&(#(?:x[0-9a-fA-F]+|\d+)|[a-zA-Z]+);/g, function (match, entity) {
+            if (entity[0] === '#') {
+                // Decode numeric entities
+                var codePoint = entity[1].toLowerCase() === 'x' ? parseInt(entity.slice(2), 16) : parseInt(entity.slice(1), 10);
+                return String.fromCodePoint(codePoint);
+            }
+            // Decode named entities
+            return {
+                amp: '&',
+                lt: '<',
+                gt: '>',
+                quot: '"',
+                apos: "'"
+            }[entity] || match;
+        });
         // Escape meta-characters to prevent XSS
         return decodedText.replace(/[&<>"']/g, function (char) {
             return {


### PR DESCRIPTION
Potential fix for [https://github.com/kuth-chi/auth-server/security/code-scanning/38](https://github.com/kuth-chi/auth-server/security/code-scanning/38)

To fix the issue, we need to ensure that untrusted data is not directly assigned to the `innerHTML` property. Instead, we should decode HTML entities in a safer way that avoids interpreting the input as HTML. A common approach is to use a library like `he` (HTML entities) to decode the text securely. Alternatively, we can use a custom decoding function that does not rely on `innerHTML`.

The fix involves replacing the use of `textarea.innerHTML` with a safer decoding mechanism. This change will occur in the `decodeHTML` function, specifically on line 5699.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
