### PR TITLE
Potential fix for code scanning alert no. 36: Information exposure through an exception

### DIFF
--- a/user/views/base.py
+++ b/user/views/base.py
@@ -76,4 +76,7 @@ def verify_token_view(request):
             claims = verify_jwt(token)
             return JsonResponse({'claims': claims})
         except Exception as e:
-            return JsonResponse({'error': str(e)}, status=400)
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.error("Error verifying token", exc_info=True)
+            return JsonResponse({'error': 'An error occurred while verifying the token.'}, status=400)


### PR DESCRIPTION
Potential fix for [https://github.com/kuth-chi/auth-server/security/code-scanning/36](https://github.com/kuth-chi/auth-server/security/code-scanning/36)

To fix the issue, we should avoid exposing the raw exception message to the user. Instead, we can log the exception details on the server for debugging purposes and return a generic error message to the user. This approach ensures that sensitive information is not leaked while still allowing developers to diagnose issues using server logs.

The changes involve:
1. Logging the exception details (e.g., using Python's `logging` module).
2. Replacing the exposed exception message with a generic error message in the response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
